### PR TITLE
Remove unnecessary private fields from Org type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@propelauth/nextjs",
-  "version": "0.0.106",
+  "version": "0.0.108",
   "exports": {
     "./server": {
       "browser": "./dist/server/index.mjs",

--- a/src/user.ts
+++ b/src/user.ts
@@ -102,9 +102,9 @@ export class OrgMemberInfo {
     public orgMetadata: { [key: string]: any }
     public urlSafeOrgName: string
 
-    private userAssignedRole: string
-    private userInheritedRolesPlusCurrentRole: string[]
-    private userPermissions: string[]
+    public userAssignedRole: string
+    public userInheritedRolesPlusCurrentRole: string[]
+    public userPermissions: string[]
 
     constructor(
         orgId: string,


### PR DESCRIPTION
In Next.js we have to split our exports (client, app router, pages router) but we do have some shared types across the server. Typescript complains about the setup specifically because of the private fields, which don't _really_ need to be private.