### PR TITLE
Adds a redirect to the API keys page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@propelauth/nextjs",
-    "version": "0.0.124",
+    "version": "0.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@propelauth/nextjs",
-            "version": "0.0.124",
+            "version": "0.1.2",
             "dependencies": {
                 "@propelauth/node-apis": "^2.1.10",
                 "jose": "^5.2.4"

--- a/src/client/AuthProvider.tsx
+++ b/src/client/AuthProvider.tsx
@@ -31,6 +31,7 @@ interface InternalAuthState {
     redirectToOrgSettingsPage: (orgId?: string, opts?: RedirectOptions) => void
     redirectToCreateOrgPage: (opts?: RedirectOptions) => void
     redirectToSetupSAMLPage: (orgId: string, opts?: RedirectOptions) => void
+    redirectToOrgApiKeysPage: (orgId?: string) => void
 
     getSignupPageUrl(opts?: RedirectToSignupOptions): string
     getLoginPageUrl(opts?: RedirectToLoginOptions): string

--- a/src/client/AuthProvider.tsx
+++ b/src/client/AuthProvider.tsx
@@ -31,7 +31,7 @@ interface InternalAuthState {
     redirectToOrgSettingsPage: (orgId?: string, opts?: RedirectOptions) => void
     redirectToCreateOrgPage: (opts?: RedirectOptions) => void
     redirectToSetupSAMLPage: (orgId: string, opts?: RedirectOptions) => void
-    redirectToOrgApiKeysPage: (orgId?: string) => void
+    redirectToOrgApiKeysPage: (orgId?: string, opts?: RedirectOptions) => void
 
     getSignupPageUrl(opts?: RedirectToSignupOptions): string
     getLoginPageUrl(opts?: RedirectToLoginOptions): string
@@ -40,7 +40,7 @@ interface InternalAuthState {
     getOrgSettingsPageUrl(orgId?: string, opts?: RedirectOptions): string
     getCreateOrgPageUrl(opts?: RedirectOptions): string
     getSetupSAMLPageUrl(orgId: string, opts?: RedirectOptions): string
-    getOrgApiKeysPageUrl(orgId?: string): string
+    getOrgApiKeysPageUrl(orgId?: string, opts?: RedirectOptions): string
 
     refreshAuthInfo: () => Promise<User | undefined>
     setActiveOrg: (orgId: string) => Promise<User | undefined>
@@ -286,11 +286,11 @@ export const AuthProvider = (props: AuthProviderProps) => {
     )
 
     const getOrgApiKeysPageUrl = useCallback(
-        (orgId?: string) => {
+        (orgId?: string, opts?: RedirectOptions) => {
             if (orgId) {
-                return addReturnToPath(`${props.authUrl}/org/api_keys/${orgId}`)
+                return addReturnToPath(`${props.authUrl}/org/api_keys/${orgId}`, opts?.redirectBackToUrl)
             } else {
-                return addReturnToPath(`${props.authUrl}/org/api_keys`)
+                return addReturnToPath(`${props.authUrl}/org/api_keys`, opts?.redirectBackToUrl)
             }
         },
         [props.authUrl]
@@ -309,7 +309,8 @@ export const AuthProvider = (props: AuthProviderProps) => {
     const redirectToCreateOrgPage = (opts?: RedirectOptions) => redirectTo(getCreateOrgPageUrl(opts))
     const redirectToSetupSAMLPage = (orgId: string, opts?: RedirectOptions) =>
         redirectTo(getSetupSAMLPageUrl(orgId, opts))
-    const redirectToOrgApiKeysPage = (orgId?: string) => redirectTo(getOrgApiKeysPageUrl(orgId))
+    const redirectToOrgApiKeysPage = (orgId?: string, opts?: RedirectOptions) =>
+        redirectTo(getOrgApiKeysPageUrl(orgId, opts))
 
     const refreshAuthInfo = useCallback(async () => {
         const action = await apiGetUserInfo()

--- a/src/client/AuthProvider.tsx
+++ b/src/client/AuthProvider.tsx
@@ -283,13 +283,13 @@ export const AuthProvider = (props: AuthProviderProps) => {
         },
         [props.authUrl]
     )
-    
+
     const getOrgApiKeysPageUrl = useCallback(
         (orgId?: string) => {
             if (orgId) {
-                return return addReturnToPath(`${props.authUrl}/org/api_keys/${orgId}`)
+                return addReturnToPath(`${props.authUrl}/org/api_keys/${orgId}`)
             } else {
-                return `${props.authUrl}/org/api_keys`
+                return addReturnToPath(`${props.authUrl}/org/api_keys`)
             }
         },
         [props.authUrl]
@@ -309,7 +309,6 @@ export const AuthProvider = (props: AuthProviderProps) => {
     const redirectToSetupSAMLPage = (orgId: string, opts?: RedirectOptions) =>
         redirectTo(getSetupSAMLPageUrl(orgId, opts))
     const redirectToOrgApiKeysPage = (orgId?: string) => redirectTo(getOrgApiKeysPageUrl(orgId))
-
 
     const refreshAuthInfo = useCallback(async () => {
         const action = await apiGetUserInfo()
@@ -352,6 +351,7 @@ export const AuthProvider = (props: AuthProviderProps) => {
         getOrgPageUrl,
         getOrgSettingsPageUrl,
         getCreateOrgPageUrl,
+        getOrgApiKeysPageUrl,
         getSetupSAMLPageUrl,
         refreshAuthInfo,
         setActiveOrg,

--- a/src/client/AuthProvider.tsx
+++ b/src/client/AuthProvider.tsx
@@ -32,6 +32,7 @@ interface InternalAuthState {
     getOrgPageUrl(orgId?: string): string
     getCreateOrgPageUrl(): string
     getSetupSAMLPageUrl(orgId: string): string
+    getOrgApiKeysPageUrl(orgId?: string): string
 
     refreshAuthInfo: () => Promise<User | undefined>
 }
@@ -235,6 +236,16 @@ export const AuthProvider = (props: AuthProviderProps) => {
         },
         [props.authUrl]
     )
+    const getOrgApiKeysPageUrl = useCallback(
+        (orgId?: string) => {
+            if (orgId) {
+                return `${props.authUrl}/org/api_keys/${orgId}`
+            } else {
+                return `${props.authUrl}/org/api_keys`
+            }
+        },
+        [props.authUrl]
+    )
 
     const redirectTo = (url: string) => {
         window.location.href = url
@@ -246,6 +257,7 @@ export const AuthProvider = (props: AuthProviderProps) => {
     const redirectToOrgPage = (orgId?: string) => redirectTo(getOrgPageUrl(orgId))
     const redirectToCreateOrgPage = () => redirectTo(getCreateOrgPageUrl())
     const redirectToSetupSAMLPage = (orgId: string) => redirectTo(getSetupSAMLPageUrl(orgId))
+    const redirectToOrgApiKeysPage = (orgId?: string) => redirectTo(getApiKeysPageUrl(orgId))
 
     const refreshAuthInfo = async () => {
         const action = await apiGetUserInfo()
@@ -263,6 +275,7 @@ export const AuthProvider = (props: AuthProviderProps) => {
         redirectToOrgPage,
         redirectToCreateOrgPage,
         redirectToSetupSAMLPage,
+        redirectToOrgApiKeysPage,
         getLoginPageUrl,
         getSignupPageUrl,
         getAccountPageUrl,

--- a/src/client/useRedirectFunctions.tsx
+++ b/src/client/useRedirectFunctions.tsx
@@ -14,6 +14,7 @@ export function useRedirectFunctions() {
         redirectToOrgSettingsPage,
         redirectToCreateOrgPage,
         redirectToSetupSAMLPage,
+        redirectToOrgApiKeysPage,
     } = context
     return {
         redirectToSignupPage,
@@ -23,6 +24,7 @@ export function useRedirectFunctions() {
         redirectToOrgSettingsPage,
         redirectToCreateOrgPage,
         redirectToSetupSAMLPage,
+        redirectToOrgApiKeysPage,
     }
 }
 


### PR DESCRIPTION
Hello ! 
I'm building a NextJS app and I like to directly redirect our user to the API keys page (for easier onboarding, etc.)
Here's a proposal on how to add it directly to the propelauth library.
Hope this helps.