### PR TITLE
Adds support for redirecting back to the current page in App Router

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@propelauth/nextjs",
-    "version": "0.0.119",
+    "version": "0.0.120",
     "exports": {
         "./server": {
             "browser": "./dist/server/index.mjs",

--- a/src/server/app-router-index.ts
+++ b/src/server/app-router-index.ts
@@ -1,3 +1,10 @@
-export {UnauthorizedException, ConfigurationException} from "./exceptions"
-export {getRouteHandlers, getUser, getUserOrRedirect, getAccessToken, authMiddleware} from "./app-router"
-export type {RouteHandlerArgs} from "./app-router"
+export { UnauthorizedException, ConfigurationException } from './exceptions'
+export {
+    getRouteHandlers,
+    getUser,
+    getUserOrRedirect,
+    getAccessToken,
+    authMiddleware,
+    getCurrentUrl,
+} from './app-router'
+export type { RouteHandlerArgs, RedirectOptions } from './app-router'

--- a/src/server/shared.ts
+++ b/src/server/shared.ts
@@ -30,6 +30,7 @@ export const ACCESS_TOKEN_COOKIE_NAME = '__pa_at'
 export const REFRESH_TOKEN_COOKIE_NAME = '__pa_rt'
 export const STATE_COOKIE_NAME = '__pa_state'
 export const CUSTOM_HEADER_FOR_ACCESS_TOKEN = 'x-propelauth-access-token'
+export const CUSTOM_HEADER_FOR_URL = 'x-propelauth-current-url'
 export const RETURN_TO_PATH_COOKIE_NAME = '__pa_return_to_path'
 
 export const COOKIE_OPTIONS: Partial<ResponseCookie> = {


### PR DESCRIPTION
This commit adds an optional argument to the `getUserOrRedirect` function which allows the user to specify one of:

getUserOrRedirect({ returnToPath: "/somewhere" })

or

getUserOrRedirect({ returnToCurrentPath: true })

The former is pretty straightforward. The later requires us to do some unfortunate workarounds with Next.js, since you don't know the current URL in server components.

Luckily, we already have the requirement that people set up middleware due to other restrictions around whether cookies can be set in the app router, so we can use that same pattern to pass the URL from middleware to the downstream function.

As long as we are doing this, it also seems like a good idea to provide a utility to other folks, so we also now expose:

`getCurrentUrl()` which has nothing to do with us, but seems generally useful.