### PR TITLE
Bump `@propelauth/node-apis` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@propelauth/nextjs",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@propelauth/nextjs",
-            "version": "0.1.4",
+            "version": "0.1.5",
             "dependencies": {
                 "@propelauth/node-apis": "^2.1.14",
                 "jose": "^5.2.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
     "name": "@propelauth/nextjs",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@propelauth/nextjs",
-            "version": "0.1.3",
+            "version": "0.1.4",
             "dependencies": {
-                "@propelauth/node-apis": "^2.1.10",
+                "@propelauth/node-apis": "^2.1.14",
                 "jose": "^5.2.4"
             },
             "devDependencies": {
@@ -615,9 +615,9 @@
             }
         },
         "node_modules/@propelauth/node-apis": {
-            "version": "2.1.10",
-            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.10.tgz",
-            "integrity": "sha512-YdCZj4tT2RIrFYsx/uf61TjtscN7o4bi8fxTu+lBlXXGJFhyUldb7Y6CY8D3zrXuz2SZ9XMp26NiaHivjlz6CA=="
+            "version": "2.1.14",
+            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.14.tgz",
+            "integrity": "sha512-B7KkXDb0oSLi3c4GRoTclvP6OHg+pfHFc/J1Wl2hXigRh7G+862xOV3/FjgHLHtlcseh8nK10O5Nj7997Z38WQ=="
         },
         "node_modules/@swc/helpers": {
             "version": "0.5.2",
@@ -2245,9 +2245,9 @@
             }
         },
         "@propelauth/node-apis": {
-            "version": "2.1.10",
-            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.10.tgz",
-            "integrity": "sha512-YdCZj4tT2RIrFYsx/uf61TjtscN7o4bi8fxTu+lBlXXGJFhyUldb7Y6CY8D3zrXuz2SZ9XMp26NiaHivjlz6CA=="
+            "version": "2.1.14",
+            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.14.tgz",
+            "integrity": "sha512-B7KkXDb0oSLi3c4GRoTclvP6OHg+pfHFc/J1Wl2hXigRh7G+862xOV3/FjgHLHtlcseh8nK10O5Nj7997Z38WQ=="
         },
         "@swc/helpers": {
             "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "react": "^18.2.0"
     },
     "dependencies": {
-        "@propelauth/node-apis": "^2.1.10",
+        "@propelauth/node-apis": "^2.1.14",
         "jose": "^5.2.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@propelauth/nextjs",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "exports": {
         "./server": {
             "browser": "./dist/server/index.mjs",


### PR DESCRIPTION
This PR bumps the dependency for the newly released `@propelauth/node-apis` library