### PR TITLE
Adds new env variable PROPELAUTH_SAME_SITE_COOKIE_OVERRIDE

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@propelauth/nextjs",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "exports": {
         "./server": {
             "browser": "./dist/server/index.mjs",

--- a/src/server/shared.ts
+++ b/src/server/shared.ts
@@ -36,7 +36,6 @@ export const RETURN_TO_PATH_COOKIE_NAME = '__pa_return_to_path'
 
 export const COOKIE_OPTIONS: Partial<ResponseCookie> = {
     httpOnly: true,
-    sameSite: 'lax',
     secure: true,
     path: '/',
 }
@@ -75,6 +74,23 @@ export function getVerifierKey() {
         throw new Error('PROPELAUTH_VERIFIER_KEY is not set')
     }
     return verifierKey.replace(/\\n/g, '\n')
+}
+
+export function getSameSiteCookieValue() {
+    const sameSiteOverride = process.env.PROPELAUTH_SAME_SITE_COOKIE_OVERRIDE
+    if (sameSiteOverride === 'none') {
+        return 'none'
+    } else if (sameSiteOverride === 'lax') {
+        return 'lax'
+    } else if (sameSiteOverride === 'strict') {
+        return 'strict'
+    } else if (sameSiteOverride) {
+        throw new Error(
+            'Invalid value for PROPELAUTH_SAME_SITE_COOKIE_OVERRIDE, must be one of "none", "lax", or "strict"'
+        )
+    } else {
+        return 'lax'
+    }
 }
 
 export async function refreshTokenWithAccessAndRefreshToken(

--- a/src/server/shared.ts
+++ b/src/server/shared.ts
@@ -76,7 +76,7 @@ export function getVerifierKey() {
     return verifierKey.replace(/\\n/g, '\n')
 }
 
-export function getSameSiteCookieValue() {
+export function getSameSiteCookieValue(): "none" | "lax" | "strict" {
     const sameSiteOverride = process.env.PROPELAUTH_SAME_SITE_COOKIE_OVERRIDE
     if (sameSiteOverride === 'none') {
         return 'none'


### PR DESCRIPTION
This allows the user to override the sameSite setting for all cookies that are being set. Values must be one of "none", "lax", or "strict"

If unset, it'll keep the default of "lax"