### PR TITLE
[FEAT] Add `minSecondsBeforeRefresh` + debounce refresh token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
     "name": "@propelauth/nextjs",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@propelauth/nextjs",
-            "version": "0.1.10",
+            "version": "0.1.11",
             "dependencies": {
-                "@propelauth/node-apis": "^2.1.21",
+                "@propelauth/node-apis": "^2.1.22",
                 "jose": "^5.2.4"
             },
             "devDependencies": {
@@ -615,9 +615,9 @@
             }
         },
         "node_modules/@propelauth/node-apis": {
-            "version": "2.1.21",
-            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.21.tgz",
-            "integrity": "sha512-YFZiHjG8MpJ6IIOXC88RTk4HYsGrjA8zLOqSpuCdZuHCX2HrkQX8JduXM2oAsFzBvCQbxquNbhEpxYRx7dCKJg=="
+            "version": "2.1.22",
+            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.22.tgz",
+            "integrity": "sha512-yjcVQRWuYT5B5gbbJTz/1S5vEfB+djQIoH906Vb48Ku683ada+MPHF28FHjeqM0xmqhIgPkiyrx/3f4sl0UUMQ=="
         },
         "node_modules/@swc/counter": {
             "version": "0.1.3",
@@ -2256,9 +2256,9 @@
             }
         },
         "@propelauth/node-apis": {
-            "version": "2.1.21",
-            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.21.tgz",
-            "integrity": "sha512-YFZiHjG8MpJ6IIOXC88RTk4HYsGrjA8zLOqSpuCdZuHCX2HrkQX8JduXM2oAsFzBvCQbxquNbhEpxYRx7dCKJg=="
+            "version": "2.1.22",
+            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.22.tgz",
+            "integrity": "sha512-yjcVQRWuYT5B5gbbJTz/1S5vEfB+djQIoH906Vb48Ku683ada+MPHF28FHjeqM0xmqhIgPkiyrx/3f4sl0UUMQ=="
         },
         "@swc/counter": {
             "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "scripts": {
         "build": "tsup",
         "dev": "tsup --watch",
-        "test": "jest"
+        "test": "jest",
+        "prepublishOnly": "npm run build"
     },
     "devDependencies": {
         "@types/node": "^20.3.1",

--- a/src/client/AuthProvider.tsx
+++ b/src/client/AuthProvider.tsx
@@ -4,7 +4,14 @@ import { useRouter } from 'next/navigation.js'
 import React, { useCallback, useEffect, useReducer, useState } from 'react'
 import { toOrgIdToOrgMemberInfo } from '../user'
 import { User } from './useUser'
-import { doesLocalStorageMatch, hasWindow, isEqual, saveUserToLocalStorage, USER_INFO_KEY } from './utils'
+import {
+    currentTimeSecs,
+    doesLocalStorageMatch,
+    hasWindow,
+    isEqual,
+    saveUserToLocalStorage,
+    USER_INFO_KEY,
+} from './utils'
 
 export interface RedirectToSignupOptions {
     postSignupRedirectPath?: string
@@ -162,6 +169,7 @@ export const AuthProvider = (props: AuthProviderProps) => {
             const action = await apiGetUserInfo()
             if (!didCancel && !action.error) {
                 dispatch(action)
+                setLastRefresh(currentTimeSecs())
             }
         }
 
@@ -190,7 +198,7 @@ export const AuthProvider = (props: AuthProviderProps) => {
             }
             if (!action.error) {
                 dispatch(action)
-                setLastRefresh(Math.floor(Date.now() / 1000))
+                setLastRefresh(currentTimeSecs())
             } else if (action.error === 'unexpected') {
                 clearAndSetRetryTimer()
             }
@@ -199,8 +207,7 @@ export const AuthProvider = (props: AuthProviderProps) => {
         // If we were offline or on a different tab, when we return, refetch auth info
         // Some browsers trigger focus more often than we'd like, so we'll debounce a little here as well
         const refreshOnOnlineOrFocus = async function () {
-            const currentTimeSecs = Math.floor(Date.now() / 1000)
-            if (lastRefresh && currentTimeSecs > lastRefresh + minSecondsBeforeRefresh) {
+            if (lastRefresh && currentTimeSecs() > lastRefresh + minSecondsBeforeRefresh) {
                 await refreshToken()
             }
         }

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -7,6 +7,10 @@ export function hasWindow(): boolean {
     return typeof window !== 'undefined'
 }
 
+export const currentTimeSecs = (): number => {
+    return Math.floor(Date.now() / 1000)
+}
+
 export function saveUserToLocalStorage(user: User | undefined) {
     if (user) {
         localStorage.setItem(USER_INFO_KEY, JSON.stringify(user))


### PR DESCRIPTION
Done as part of: https://www.notion.so/Client-Library-Updates-11753e303ce68051abf0cf4d570ee98e

# Background
The original behavior before these changes was that in an application, on page focus, the `/userinfo` endpoint would be called each time. This was unnecessary, and would spam these network calls. Now, a user can pass in a prop `minSecondsBeforeRefresh` that will only call the endpoint after that time has passed. This logic is the same as in the JS library. 

## Smoke Tests

* When not passing in a prop, and clicking around the page, the refresh only happens after the expiration time has passed. 
* When passing in a prop of 5 seconds, the `/userinfo` endpoint only gets called after those seconds are up, and after clicking on the page to focus it. 