### PR TITLE
bump node-apis version to 2.1.26 and re-export types

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "react": "^18.2.0"
     },
     "dependencies": {
-        "@propelauth/node-apis": "^2.1.22",
+        "@propelauth/node-apis": "^2.1.26",
         "jose": "^5.2.4"
     }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -58,4 +58,7 @@ export type {
     PendingInvitesPage,
     PendingInvite,
     RevokePendingOrgInviteRequest,
+    FetchSamlSpMetadataResponse,
+    SetSamlIdpMetadataRequest,
+    IdpProvider,
 } from '@propelauth/node-apis'


### PR DESCRIPTION
depends on [this node-apis PR](https://github.com/PropelAuth/node-apis/pull/26) merging and a patch version bump there