### PR TITLE
bump node-apis, ApiKeyValidateRateLimitedException

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@propelauth/nextjs",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "exports": {
         "./server": {
             "browser": "./dist/server/index.mjs",
@@ -68,7 +68,7 @@
         "react": "^18.2.0 || ^19.0.0"
     },
     "dependencies": {
-        "@propelauth/node-apis": "^2.1.26",
+        "@propelauth/node-apis": "^2.1.27",
         "jose": "^5.2.4"
     }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -17,6 +17,7 @@ export type {
     ApiKeyUpdateException,
     ApiKeyUpdateRequest,
     ApiKeyValidateException,
+    ApiKeyValidateRateLimitedException,
     ApiKeyValidation,
     ApiKeysCreateRequest,
     ApiKeysQueryRequest,


### PR DESCRIPTION
## After PR
1. bumps `node-apis` to version 2.1.27
2. re-exports `ApiKeyValidateRateLimitedException`. See [parent PR](https://github.com/PropelAuth/node-apis/pull/28) for details on usage.
3. bumps package version to 0.3.1

## Tests
Verified expected behavior of parent PR repo in an example application. See more details on the parent PR.