### PR TITLE
Add a new middleware option which includes an afterAuthHook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@propelauth/nextjs",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "exports": {
         "./server": {
             "browser": "./dist/server/index.mjs",

--- a/src/server/app-router-index.ts
+++ b/src/server/app-router-index.ts
@@ -11,3 +11,5 @@ export {
     getCurrentPathAsync,
 } from './app-router'
 export type { RouteHandlerArgs, RedirectOptions } from './app-router'
+export { AuthHookResponse } from './middleware/auth-hook-response'
+export type { PropelAuthMiddlewareOptions } from './middleware/advanced-middleware'

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,6 +4,7 @@ export { UserFromToken, OrgMemberInfo } from '../user'
 export { UnauthorizedException, ConfigurationException } from './exceptions'
 export { getPropelAuthApis } from './api'
 export { AuthHookResponse } from './middleware/auth-hook-response'
+export { buildAuthMiddleware } from './middleware/advanced-middleware'
 export type { PropelAuthMiddlewareOptions } from './middleware/advanced-middleware'
 export type {
     AccessToken,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,6 +3,8 @@ export type { OrgIdToOrgMemberInfo } from '../user'
 export { UserFromToken, OrgMemberInfo } from '../user'
 export { UnauthorizedException, ConfigurationException } from './exceptions'
 export { getPropelAuthApis } from './api'
+export { AuthHookResponse } from './middleware/auth-hook-response'
+export type { PropelAuthMiddlewareOptions } from './middleware/advanced-middleware'
 export type {
     AccessToken,
     AccessTokenCreationException,

--- a/src/server/middleware/advanced-middleware.ts
+++ b/src/server/middleware/advanced-middleware.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+    ACCESS_TOKEN_COOKIE_NAME,
+    CALLBACK_PATH,
+    COOKIE_OPTIONS,
+    LOGOUT_PATH,
+    REFRESH_TOKEN_COOKIE_NAME,
+    USERINFO_PATH,
+    getSameSiteCookieValue,
+    refreshTokenWithAccessAndRefreshToken,
+    validateAccessToken,
+    validateAccessTokenOrUndefined,
+} from '../shared'
+import { ACTIVE_ORG_ID_COOKIE_NAME } from '../../shared'
+import { getNextResponse } from '../app-router'
+import { UserFromToken } from '../../user'
+import { AuthHookResponse } from './auth-hook-response'
+
+export type PropelAuthMiddlewareOptions = {
+    afterAuthHook?: (req: NextRequest, res: NextResponse, user?: UserFromToken) => Promise<AuthHookResponse>
+}
+
+// Purpose of this middleware is just to keep the access token cookie alive
+// In an ideal world, this could be done in `getUser`, however, you can't
+//   set a cookie in a server component.
+// There also doesn't seem to be any way right now to set a cookie in a
+//   middleware and pass it forward (you can only set them on the response).
+// You CAN, however, pass in custom headers,
+//   so we'll use CUSTOM_HEADER_FOR_ACCESS_TOKEN as a workaround
+export function buildAuthMiddleware(options?: PropelAuthMiddlewareOptions): (req: NextRequest) => Promise<Response> {
+    return async (req: NextRequest) => {
+        if (
+            req.nextUrl.pathname === CALLBACK_PATH ||
+            req.nextUrl.pathname === LOGOUT_PATH ||
+            req.nextUrl.pathname === USERINFO_PATH
+        ) {
+            // Don't do anything for the callback, logout, or userinfo paths, as they will modify the cookies themselves
+            return getNextResponse(req)
+        }
+
+        const accessToken = req.cookies.get(ACCESS_TOKEN_COOKIE_NAME)?.value
+        const refreshToken = req.cookies.get(REFRESH_TOKEN_COOKIE_NAME)?.value
+        const activeOrgId = req.cookies.get(ACTIVE_ORG_ID_COOKIE_NAME)?.value
+
+        // If we are authenticated, we can continue
+        if (accessToken) {
+            const user = await validateAccessTokenOrUndefined(accessToken)
+            if (user) {
+                const nextResponse = getNextResponse(req)
+                return await handlePostAuthHook(req, nextResponse, user, options)
+            }
+        }
+
+        // Otherwise, we need to refresh the access token
+        if (refreshToken) {
+            const response = await refreshTokenWithAccessAndRefreshToken(refreshToken, activeOrgId)
+            if (response.error === 'unexpected') {
+                throw new Error('Unexpected error while refreshing access token')
+            } else if (response.error === 'unauthorized') {
+                const response = getNextResponse(req)
+                response.cookies.delete(ACCESS_TOKEN_COOKIE_NAME)
+                response.cookies.delete(REFRESH_TOKEN_COOKIE_NAME)
+                return await handlePostAuthHook(req, response, undefined, options)
+            } else {
+                const sameSite = getSameSiteCookieValue()
+                const nextResponse = getNextResponse(req, response.accessToken)
+                nextResponse.cookies.set(ACCESS_TOKEN_COOKIE_NAME, response.accessToken, {
+                    ...COOKIE_OPTIONS,
+                    sameSite,
+                })
+                nextResponse.cookies.set(REFRESH_TOKEN_COOKIE_NAME, response.refreshToken, {
+                    ...COOKIE_OPTIONS,
+                    sameSite,
+                })
+                const user = await validateAccessToken(response.accessToken)
+                return await handlePostAuthHook(req, nextResponse, user, options)
+            }
+        }
+
+        const res = getNextResponse(req)
+        return await handlePostAuthHook(req, res, undefined, options)
+    }
+}
+
+const handlePostAuthHook = async (
+    req: NextRequest,
+    res: NextResponse,
+    user?: UserFromToken,
+    options?: PropelAuthMiddlewareOptions
+): Promise<NextResponse> => {
+    if (options?.afterAuthHook) {
+        const hookResponse = await options.afterAuthHook(req, res, user)
+        if (hookResponse instanceof AuthHookResponse) {
+            if (!hookResponse.shouldContinue()) {
+                return hookResponse.getResponse() ?? res
+            }
+        } else {
+            console.warn('afterAuthHook did not return a AuthHookResponse, continuing')
+        }
+    }
+    return res
+}

--- a/src/server/middleware/auth-hook-response.ts
+++ b/src/server/middleware/auth-hook-response.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+
+export class AuthHookResponse {
+    private constructor(
+        private readonly type: 'continue' | 'reject',
+        private readonly response?: NextResponse
+    ) {}
+
+    static continue(): AuthHookResponse {
+        return new AuthHookResponse('continue')
+    }
+
+    static reject(response: NextResponse): AuthHookResponse {
+        return new AuthHookResponse('reject', response)
+    }
+
+    shouldContinue(): boolean {
+        return this.type === 'continue'
+    }
+
+    getResponse(): NextResponse | undefined {
+        return this.response
+    }
+}


### PR DESCRIPTION
Example usage:

```
export const middleware = buildAuthMiddleware({
  afterAuthHook: (req: NextRequest, res: NextResponse, user?: UserFromToken) => {
    if (!user && isProtectedRoute(req.nextUrl.pathname)) {
      return AuthHookResponse.reject(new NextResponse(undefined, { status: 401 }))
    } else {
      return AuthHookResponse.continue()
    }
  }
})

const isProtectedRoute = (path: string) => {
  // compare with regex or a list, really whatever
}
```