### PR TITLE
Add PROPELAUTH_AUTH_URL env var support for runtime auth URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ When you copy the PROPELAUTH_VERIFIER_KEY from the PropelAuth dashboard, it will
 PROPELAUTH_VERIFIER_KEY=-----BEGIN PUBLIC KEY-----\nMIIBIjANBgk...
 ```
 
-For most applications, setting `NEXT_PUBLIC_AUTH_URL` during build time is sufficient. However, in case auth URL is needed to be set at runtime, you can use `PROPELAUTH_AUTH_URL`.
-Auth url will be fetched from `PROPELAUTH_AUTH_URL` if present and fall back to `NEXT_PUBLIC_AUTH_URL` if not.
+If authentication URL needs to be set at runtime, use `PROPELAUTH_AUTH_URL`. Otherwise, it falls back to `NEXT_PUBLIC_AUTH_URL`, which is set at build time.
 
 For the PROPELAUTH_REDIRECT_URI variable, you need to add /api/auth/callback to the end of one of your allowed frontend locations. So, for example, if you are developing in the test environment and using http://localhost:3000, you would use http://localhost:3000/api/auth/callback 
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ Before you start, make sure you have a PropelAuth account. You can sign up for f
 You'll need to set the following .env variables in your Next.js application:
 
 - NEXT_PUBLIC_AUTH_URL
+- PROPELAUTH_AUTH_URL (optional)
 - PROPELAUTH_API_KEY
 - PROPELAUTH_VERIFIER_KEY
 - PROPELAUTH_REDIRECT_URI
 
-You can find the NEXT_PUBLIC_AUTH_URL, PROPELAUTH_API_KEY, and PROPELAUTH_VERIFIER_KEY variables for your application in the PropelAuth Dashboard under Backend Integration.
+You can find the NEXT_PUBLIC_AUTH_URL, PROPELAUTH_AUTH_URL, PROPELAUTH_API_KEY, and PROPELAUTH_VERIFIER_KEY variables for your application in the PropelAuth Dashboard under Backend Integration.
 
 When you copy the PROPELAUTH_VERIFIER_KEY from the PropelAuth dashboard, it will automatically paste into your .env file with line breaks. However, due to the way some systems interpret multiline environment variables, you will need to edit the verifier key value to include ‘\n’ instead of newline characters. For example:
 
@@ -31,6 +32,8 @@ When you copy the PROPELAUTH_VERIFIER_KEY from the PropelAuth dashboard, it will
 PROPELAUTH_VERIFIER_KEY=-----BEGIN PUBLIC KEY-----\nMIIBIjANBgk...
 ```
 
+For most applications, setting `NEXT_PUBLIC_AUTH_URL` during build time is sufficient. However, in case auth URL is needed to be set at runtime, you can use `PROPELAUTH_AUTH_URL`.
+Auth url will be fetched from `PROPELAUTH_AUTH_URL` if present and fall back to `NEXT_PUBLIC_AUTH_URL` if not.
 
 For the PROPELAUTH_REDIRECT_URI variable, you need to add /api/auth/callback to the end of one of your allowed frontend locations. So, for example, if you are developing in the test environment and using http://localhost:3000, you would use http://localhost:3000/api/auth/callback 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@propelauth/nextjs",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "exports": {
         "./server": {
             "browser": "./dist/server/index.mjs",

--- a/src/server/shared.ts
+++ b/src/server/shared.ts
@@ -45,7 +45,7 @@ export function getAuthUrlOrigin() {
 }
 
 export function getAuthUrl() {
-    const authUrl = process.env.NEXT_PUBLIC_AUTH_URL
+    const authUrl = process.env.PROPELAUTH_AUTH_URL || process.env.NEXT_PUBLIC_AUTH_URL
     if (!authUrl) {
         throw new Error('NEXT_PUBLIC_AUTH_URL is not set')
     }


### PR DESCRIPTION
This PR enhances authentication URL configuration by allowing runtime overrides via PROPELAUTH_AUTH_URL.

#### Motivation
We need the flexibility to determine the authentication URL at runtime instead of hardcoding it during build time. This eliminates the need to create separate builds for different use cases.

#### Changes
Updated getAuthUrl() to check PROPELAUTH_AUTH_URL first, falling back to NEXT_PUBLIC_AUTH_URL if not set.
Maintains backward compatibility while enabling runtime configuration.