### PR TITLE
Revert the `.js` import change temporarily to place on a branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@propelauth/nextjs",
-    "version": "0.3.9",
+    "version": "0.3.10-withjs.0",
     "exports": {
         "./server": {
             "browser": "./dist/server/index.mjs",

--- a/src/client/AuthProvider.tsx
+++ b/src/client/AuthProvider.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useCallback, useEffect, useReducer } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter } from 'next/navigation.js'
 import { currentTimeSecs, hasWindow, isEqual } from './utils'
 import { User } from './useUser'
 import { toOrgIdToOrgMemberInfo } from '../user'

--- a/src/server/app-router.ts
+++ b/src/server/app-router.ts
@@ -1,6 +1,6 @@
-import { redirect } from 'next/navigation'
-import { cookies, headers } from 'next/headers'
-import { NextRequest, NextResponse } from 'next/server'
+import { redirect } from 'next/navigation.js'
+import { cookies, headers } from 'next/headers.js'
+import { NextRequest, NextResponse } from 'next/server.js'
 import {
     ACCESS_TOKEN_COOKIE_NAME,
     CALLBACK_PATH,


### PR DESCRIPTION
This is a simpler (albeit not as generally useful) version of https://github.com/PropelAuth/nextjs/pull/67

We'll need to do more testing on different versions for that, so this is a simpler fix that can unblock specific versions of Next