### PR TITLE
Revert "Revert the `.js` import change temporarily to place on a branch"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@propelauth/nextjs",
-    "version": "0.3.10-withjs.0",
+    "version": "0.3.9",
     "exports": {
         "./server": {
             "browser": "./dist/server/index.mjs",

--- a/src/client/AuthProvider.tsx
+++ b/src/client/AuthProvider.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useCallback, useEffect, useReducer } from 'react'
-import { useRouter } from 'next/navigation.js'
+import { useRouter } from 'next/navigation'
 import { currentTimeSecs, hasWindow, isEqual } from './utils'
 import { User } from './useUser'
 import { toOrgIdToOrgMemberInfo } from '../user'

--- a/src/server/app-router.ts
+++ b/src/server/app-router.ts
@@ -1,6 +1,6 @@
-import { redirect } from 'next/navigation.js'
-import { cookies, headers } from 'next/headers.js'
-import { NextRequest, NextResponse } from 'next/server.js'
+import { redirect } from 'next/navigation'
+import { cookies, headers } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
 import {
     ACCESS_TOKEN_COOKIE_NAME,
     CALLBACK_PATH,


### PR DESCRIPTION
Reverts PropelAuth/nextjs#68

It appears as though this is a pages vs app router issue. We can solve the pages router problem by being added to `transpilePackages` in the nextConfig which we'll recommend instead