### PR TITLE
re-export types for user-insights apis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@propelauth/nextjs",
-    "version": "0.3.16",
+    "version": "0.3.17",
     "exports": {
         "./server": {
             "browser": "./dist/server/index.mjs",
@@ -68,7 +68,7 @@
         "react": "^18.2.0 || ^19.0.0"
     },
     "dependencies": {
-        "@propelauth/node-apis": "^2.1.34",
+        "@propelauth/node-apis": "^2.1.35",
         "jose": "^5.10.0"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@propelauth/node-apis':
-        specifier: ^2.1.34
-        version: 2.1.34
+        specifier: ^2.1.35
+        version: 2.1.35
       jose:
         specifier: ^5.10.0
         version: 5.10.0
@@ -257,8 +257,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@propelauth/node-apis@2.1.34':
-    resolution: {integrity: sha512-WaXwpImGq+vKb4OXapdk66RU5zwoldGzU5jYBtbAp0VYs6XCjuaJQJKV+QpbIWNFzT+reiUtHNZyDb4MWPr0EQ==}
+  '@propelauth/node-apis@2.1.35':
+    resolution: {integrity: sha512-eXnC+bZwo9CD1xNUT8kAYpOVs/CiDsGgmYemSH1ULWKAQ7Nhck7um7xl6oU0NkCf/REZK01Gt//EN3fc5x0Zmg==}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -833,7 +833,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@propelauth/node-apis@2.1.34': {}
+  '@propelauth/node-apis@2.1.35': {}
 
   '@swc/counter@0.1.3': {}
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -95,3 +95,23 @@ export type {
     MfaTotpType,
     ApiKeyImportException
 } from '@propelauth/node-apis'
+export {
+    ReengagementReportInterval,
+    ChampionReportInterval,
+    ChurnReportInterval, 
+    GrowthReportInterval,
+    AttritionReportInterval,
+    TopInviterReportInterval,
+    ChartMetric,
+    ChartMetricCadence,
+} from "@propelauth/node-apis"
+export type {
+    ReportPagination,
+    UserReport,
+    UserReportRecord,
+    OrgReport,
+    OrgReportRecord,
+    UserOrgMembershipForReport,
+    ChartData,
+    ChartDataPoint,
+} from "@propelauth/node-apis"


### PR DESCRIPTION
Includes 
- version bump on node-api dep.
- this package version bump by patch to `0.3.17`
Depends on [this upstream PR](https://github.com/PropelAuth/node/pull/71)